### PR TITLE
0.1.2 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+test-data/
+pileup.png

--- a/ambigviz.py
+++ b/ambigviz.py
@@ -32,12 +32,10 @@ class BamVisualiser:
             self.get_base_counts(int(position), min_depth) for position in positions
         ]
         pileup_df = pd.DataFrame(rows_list)
-        print(pileup_df)
         return pileup_df
 
     def get_base_counts(self, position, min_depth):
         base_counts_dict = {"position": position, "A": 0, "T": 0, "C": 0, "G": 0}
-        print(position)
         pileup_columns = self.bam_file.count_coverage(
             contig=self.ref_name,
             start=position - 1,

--- a/ambigviz.py
+++ b/ambigviz.py
@@ -53,55 +53,37 @@ class BamVisualiser:
 
     def plot_pileup(self, df, title, fig_width, individual):
         fig, ax = plt.subplots(figsize=(fig_width, 5))
-
-        # Define the bar colors
         colors = ["#60935D", "#E63946", "#1B5299", "#F5BB00"]
 
         df.plot(x="position", kind="bar", stacked=True, color=colors, ax=ax)
 
         # Formatting
-        ax.set_xlabel("Position")
-        ax.set_ylabel("Count")
-        # Move the legend to outside the plot
-        ax.legend(bbox_to_anchor=(1.05, 1), loc="upper left", borderaxespad=0.0)
+        ax.set(xlabel="Position", ylabel="Count")
+        ax.legend(bbox_to_anchor=(1.05, 1))
         ax.set_title(f"Ambiguous bases in BAM file at positions {title}")
 
-        # Annotation to match bar order
+        # Annotation
         bar_order = df.columns[1:][::-1]
-        for j, row in df.iterrows():
+        for idx, row in df.iterrows():
             if individual:
-                for c in ax.containers:
-                    column = c.get_label()
+                for container in ax.containers:
                     labels = [
-                        f"{column}: {str(v.get_height())}" if v.get_height() > 0 else ""
-                        for v in c
+                        f"{container}: {bar.get_height()}"
+                        if bar.get_height() > 0
+                        else ""
+                        for container, bar in zip(bar_order, container)
                     ]
-                    print(labels)
-                    ax.bar_label(
-                        c,
-                        labels=labels,
-                        label_type="center",
-                        size=8,
-                    )
+                    ax.bar_label(container, labels=labels, label_type="center", size=8)
             else:
                 total_count = row[bar_order].sum()
                 annotation_text = "\n".join(
-                    f"{column}: {count}"
-                    for column, count in zip(bar_order, row[bar_order])
+                    f"{container}: {count}"
+                    for container, count in zip(bar_order, row[bar_order])
                     if count > 0
                 )
-
-                x = j
+                x = idx
                 y = total_count / 2
-
-                ax.annotate(
-                    annotation_text,
-                    xy=(x, y),
-                    xytext=(x, y),
-                    ha="center",
-                    va="center",
-                    color="black",
-                )
+                ax.annotate(annotation_text, xy=(x, y), ha="center", va="center")
 
         plt.savefig("pileup.png")
 
@@ -139,7 +121,7 @@ class BamVisualiser:
             "G": [0, 0, 40, 50, 60, 0],
         }
         test_df = pd.DataFrame(data)
-        self.plot_pileup(test_df, "140-145", 20, True)
+        self.plot_pileup(test_df, "140-145", 20, False)
 
 
 def parse_args():

--- a/ambigviz.py
+++ b/ambigviz.py
@@ -4,7 +4,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 
 __author__ = "Sam Sims"
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 
 class BamVisualiser:
@@ -106,13 +106,14 @@ class BamVisualiser:
         if args.percentages:
             pileup_df = self.pileup_percentages(pileup_df)
 
-        figure_to_plot = self.plot_pileup(pileup_df, title, args.fig_width, args.individual_annotations)
+        figure_to_plot = self.plot_pileup(
+            pileup_df, title, args.fig_width, args.individual_annotations
+        )
 
         # Outputs
         figure_to_plot.savefig(args.output, bbox_inches="tight")
         if args.save_counts:
             pileup_df.to_csv(args.save_counts, index=False)
-
 
     def test(self):
         data = {

--- a/ambigviz.py
+++ b/ambigviz.py
@@ -85,7 +85,7 @@ class BamVisualiser:
                 y = total_count / 2
                 ax.annotate(annotation_text, xy=(x, y), ha="center", va="center")
 
-        plt.savefig("pileup.png")
+        return fig
 
     def pileup_percentages(self, pileup_df):
         total_counts = pileup_df[["A", "T", "C", "G"]].sum(axis=1)
@@ -106,11 +106,13 @@ class BamVisualiser:
         if args.percentages:
             pileup_df = self.pileup_percentages(pileup_df)
 
-        self.plot_pileup(pileup_df, title, args.fig_width, args.individual_annotations)
+        figure_to_plot = self.plot_pileup(pileup_df, title, args.fig_width, args.individual_annotations)
 
-        # save the counts to a csv file
+        # Outputs
+        figure_to_plot.savefig(args.output, bbox_inches="tight")
         if args.save_counts:
             pileup_df.to_csv(args.save_counts, index=False)
+
 
     def test(self):
         data = {
@@ -123,15 +125,19 @@ class BamVisualiser:
         test_df = pd.DataFrame(data)
         self.plot_pileup(test_df, "140-145", 20, False)
 
+
 # fmt: off
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Visualise ambiguous posistions in a BAM file"
     )
-    parser.add_argument("-b", 
-                        "--bam", 
+    parser.add_argument("-b", "--bam", 
                         help="BAM file to visualise", 
                         required=True)
+    
+    parser.add_argument("-o", "--output",
+                        help="Output file name",
+                        default="pileup.png")
     
     parser.add_argument("--positions", 
                         help="Positions to visualise")

--- a/ambigviz.py
+++ b/ambigviz.py
@@ -123,38 +123,56 @@ class BamVisualiser:
         test_df = pd.DataFrame(data)
         self.plot_pileup(test_df, "140-145", 20, False)
 
-
+# fmt: off
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Visualise ambiguous posistions in a BAM file"
     )
-    parser.add_argument("-b", "--bam", help="BAM file to visualise", required=True)
-    parser.add_argument("--positions", help="Positions to visualise")
-    parser.add_argument("--start_pos", help="Start position to visualise", type=int)
-    parser.add_argument("--end_pos", help="End position to visualise", type=int)
-    parser.add_argument(
-        "--percentages", help="Show percentages instead of counts", action="store_true"
+    parser.add_argument("-b", 
+                        "--bam", 
+                        help="BAM file to visualise", 
+                        required=True)
+    
+    parser.add_argument("--positions", 
+                        help="Positions to visualise")
+    
+    parser.add_argument("--start_pos", 
+                        help="Start position to visualise", 
+                        type=int)
+    
+    parser.add_argument("--end_pos", 
+                        help="End position to visualise", 
+                        type=int)
+    
+    parser.add_argument("--percentages",
+                        help="Show percentages instead of counts", 
+                        action="store_true"
     )
-    parser.add_argument(
-        "--min_depth", help="Minimum depth to visualise", default=0, type=int
+    parser.add_argument("--min_depth", 
+                        help="Minimum depth to visualise", 
+                        default=0, 
+                        type=int
     )
-    parser.add_argument("--save_counts", help="Save counts to csv file")
-    parser.add_argument(
-        "--fig_width", help="Adjust width of figure", default=20, type=int
+    parser.add_argument("--save_counts", 
+                        help="Save counts to csv file")
+    
+    parser.add_argument("--fig_width", 
+                        help="Adjust width of figure", 
+                        default=20, 
+                        type=int
     )
-    parser.add_argument(
-        "--individual_annotations",
-        help="Show individual annotations",
-        action="store_true",
+    parser.add_argument("--individual_annotations",
+                        help="Show individual annotations",
+                        action="store_true",
     )
     return parser.parse_args()
+# fmt: on
 
 
 def main():
     args = parse_args()
     bam_vis = BamVisualiser(args.bam)
     bam_vis.visualise(args)
-    # bam_vis.test()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Version bump to 0.1.2
- Various refactors for a ~60% speed up - especially when reading large BAMs
- `--output` argument to specify the output path for  the plot